### PR TITLE
Allow to open Master with read-only access

### DIFF
--- a/examples/info.rs
+++ b/examples/info.rs
@@ -1,5 +1,7 @@
+use ethercat::{Master, MasterAccess};
+
 pub fn main() -> Result<(), std::io::Error> {
-    let master = ethercat::Master::reserve(0)?;
+    let master = Master::open(0, MasterAccess::ReadWrite)?;
     let info = master.get_info();
     println!("EtherCAT Master: {:#?}", info);
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,7 @@ use ethercat_sys as ec;
 mod master;
 mod types;
 
-pub use self::master::{Domain, Master, SlaveConfig};
-pub use self::types::*;
+pub use self::{
+    master::{Domain, Master, MasterAccess, SlaveConfig},
+    types::*,
+};

--- a/src/master.rs
+++ b/src/master.rs
@@ -63,6 +63,13 @@ impl Master {
         Ok(master)
     }
 
+    pub fn master_count() -> Result<usize> {
+        let master = Self::open(0, MasterAccess::ReadOnly)?;
+        let mut module_info = ec::ec_ioctl_module_t::default();
+        ioctl!(master, ec::ioctl::MODULE, &mut module_info)?;
+        Ok(module_info.master_count as usize)
+    }
+
     pub fn reserve(&self) -> Result<()> {
         ioctl!(self, ec::ioctl::REQUEST)?;
         Ok(())


### PR DESCRIPTION
## Motivation
I tried to periodically receive PDOs and execute the `Master::sdo_upload` method once in a while but that leads to a totally blocked process (zombie process). I have no idea why.

Then I tried to do the cycles with my Rust application and manually read/write SDOs via the CLI (e.g.`/opt/etherlab/bin/ethercat download -t float 0x8022 1 10.9`) and it worked fine.

So I had a look at the CLI code (`CommandUpload.cpp`) where 
I found this line that creates the access:

```cpp
m.open(MasterDevice::Read);
```
which executes this code (`tool/MasterDevice.cpp`):

```cpp
void MasterDevice::open(Permissions perm)
{
    stringstream deviceName;


    if (fd == -1) { // not already open
        ec_ioctl_module_t module_data;
        deviceName << "/dev/EtherCAT" << index;


        if ((fd = ::open(deviceName.str().c_str(),
                        perm == ReadWrite ? O_RDWR : O_RDONLY)) == -1) {
            stringstream err;
            err << "Failed to open master device " << deviceName.str() << ": "
                << strerror(errno);
            throw MasterDeviceException(err);
        }


        getModule(&module_data);
        if (module_data.ioctl_version_magic != EC_IOCTL_VERSION_MAGIC) {
            stringstream err;
            err << "ioctl() version magic is differing: "
                << deviceName.str() << ": " << module_data.ioctl_version_magic
                << ", ethercat tool: " << EC_IOCTL_VERSION_MAGIC;
            throw MasterDeviceException(err);
        }
        masterCount = module_data.master_count;
    }
}
```
This looks similar to the `reserve` method in the rust wrapper:

```rust
    pub fn reserve(index: MasterIndex) -> Result<Self> {
        let devpath = format!("/dev/EtherCAT{}", index);
        let file = OpenOptions::new().read(true).write(true).open(&devpath)?;
        let mut module_info = ec::ec_ioctl_module_t::default();
        let master = Master {
            file,
            map: None,
            domains: HashMap::new(),
        };
        ioctl!(master, ec::ioctl::MODULE, &mut module_info)?;
        if module_info.ioctl_version_magic != ec::EC_IOCTL_VERSION_MAGIC {
            Err(Error::new(
                ErrorKind::Other,
                format!(
                    "module version mismatch: expected {}, found {}",
                    ec::EC_IOCTL_VERSION_MAGIC,
                    module_info.ioctl_version_magic
                ),
            ))
        } else {
            ioctl!(master, ec::ioctl::REQUEST)?;
            Ok(master)
        }
    }
```

The main difference is this line:

```rust
ioctl!(master, ec::ioctl::REQUEST)?;
```

## Solution

My solution was to add a `open` method to the `Master` that does not contain the line `ioctl!(master, ec::ioctl::REQUEST)?;` and now I'm able to create another `Master` instance within an other thread where I can call `Master::sdo_upload` that actually works :)

## Open Questions

- Is this PR a good idea in general?
- how could the `open` method look like?
  - `open(idx: MasterIndex, write_access: bool)`
  - `open(idx: MasterIndex, access: MasterAccess)` with `enum MasterAccess { ReadOnly, ReadWrite }`
  - `open_ro(idx: MasterIndex)`
  - `open_rw(idx: MasterIndex)`
- What should be returned?
  -  `Result<Master>`
  -  `Result<(Master, usize)>` to get also `module_data.master_count`?