### PR TITLE
Add foe-read and foe-write command with examples

### DIFF
--- a/examples/foe-read.rs
+++ b/examples/foe-read.rs
@@ -1,0 +1,22 @@
+use ethercat::{Master, MasterAccess};
+
+fn main() -> Result<(), std::io::Error> {
+    let mut master = Master::open(0, MasterAccess::ReadWrite)?;
+
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: foe-read <slave-position> <foe-name>");
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Not enough arguments",
+        ));
+    }
+    let slave_idx: ethercat::SlavePos = args[1]
+        .parse::<u16>()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+        .into();
+    let foe_name = &args[2];
+    let res = master.foe_read(slave_idx, foe_name)?;
+    println!("FoE data: {:x?}, {} bytes", res, res.len());
+    Ok(())
+}

--- a/examples/foe-write.rs
+++ b/examples/foe-write.rs
@@ -1,0 +1,24 @@
+use ethercat::{Master, MasterAccess};
+
+fn main() -> Result<(), std::io::Error> {
+    let mut master = Master::open(0, MasterAccess::ReadWrite)?;
+
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 4 {
+        eprintln!("Usage: foe-read <slave-position> <foe-name> <file>");
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Not enough arguments",
+        ));
+    }
+    let slave_idx = args[1]
+        .parse::<u16>()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+        .into();
+    let foe_name = &args[2];
+    let file = &args[3];
+    let buf = std::fs::read(file)?;
+
+    master.foe_write(slave_idx, foe_name, &buf)?;
+    Ok(())
+}

--- a/src/master.rs
+++ b/src/master.rs
@@ -517,7 +517,100 @@ impl Master {
         Ok(time)
     }
 
+    pub fn foe_read(&mut self, idx: SlavePos, name: &str) -> Result<Vec<u8>> {
+        let file_name = string_to_foe_name(name)?;
+        // FIXME: this is the same as in the c-implementation. Should read in chunks instead of a
+        // fixed size buffer. The ioctl-call in the master pre-allocates a 10000 byte buffer, so we
+        // do the same here.
+        const FOE_SIZE: usize = 10_000;
+        let mut buf: Vec<u8> = vec![0; FOE_SIZE];
+        let mut data = ec::ec_ioctl_slave_foe_t {
+            slave_position: idx.into(),
+            offset: 0,
+            buffer_size: FOE_SIZE as u64,
+            buffer: buf.as_mut_ptr(),
+            file_name,
+            ..Default::default()
+        };
+        ioctl!(self, ec::ioctl::SLAVE_FOE_READ, &mut data)?;
+
+        assert!(data.data_size <= FOE_SIZE as u64);
+        buf.truncate(data.data_size as usize);
+        Ok(buf)
+    }
+
+    pub fn foe_write(&mut self, idx: SlavePos, name: &str, data: &[u8]) -> Result<()> {
+        let file_name = string_to_foe_name(name)?;
+
+        let buffer = data.as_ptr() as *mut _;
+        let data = ec::ec_ioctl_slave_foe_t {
+            slave_position: idx.into(),
+            offset: 0,
+            buffer_size: data.len() as u64,
+            buffer,
+            file_name,
+            ..Default::default()
+        };
+        ioctl!(self, ec::ioctl::SLAVE_FOE_WRITE, &data)?;
+
+        Ok(())
+    }
+
     // XXX missing: write_idn, read_idn
+}
+
+fn string_to_foe_name(input: &str) -> Result<[std::os::raw::c_char; 32]> {
+    if input.len() > 32 {
+        let e = io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "FoE name can have a maximum length of 32, '{}' has {}",
+                input,
+                input.len()
+            ),
+        );
+        return Err(Error::Io(e));
+    }
+    let mut foe_name: [std::os::raw::c_char; 32] = [0; 32];
+    input
+        .as_bytes()
+        .iter()
+        .zip(&mut foe_name)
+        .for_each(|(i, r)| *r = *i as _);
+    Ok(foe_name)
+}
+
+#[test]
+fn test_string_to_foe_name() {
+    let cmp = |s: String, chars: [i8; 32]| {
+        let arr: Vec<i8> = s.as_bytes().iter().map(|c| *c as i8).collect();
+        assert_eq!(chars.len(), 32);
+        assert_eq!(chars[0..arr.len()], arr);
+        assert_eq!(chars[arr.len()..], vec![0; 32 - s.len()]);
+    };
+
+    let name = String::from("some Name of a FoE file");
+    let chars = string_to_foe_name(&name).expect("Name is ok");
+    cmp(name, chars);
+
+    let name = String::from("short");
+    let chars = string_to_foe_name(&name).expect("Name is ok");
+    cmp(name, chars);
+
+    let name = String::from("\u{2665}\u{1F494};");
+    let chars = string_to_foe_name(&name).expect("Name is ok");
+    cmp(name, chars);
+
+    let name = String::from("a name that is just too long so we'll see what happens");
+    let e = string_to_foe_name(&name).unwrap_err();
+    assert_eq!(
+        e.to_string(),
+        format!(
+            "FoE name can have a maximum length of 32, '{}' has {}",
+            name,
+            name.len()
+        )
+    );
 }
 
 fn c_array_to_string(data: *const i8) -> String {


### PR DESCRIPTION
This patch adds the FoE Read and Write functionality similar to https://gitlab.com/etherlab.org/ethercat/-/blob/master/tool/CommandFoeRead.cpp and https://gitlab.com/etherlab.org/ethercat/-/blob/master/tool/CommandFoeWrite.cpp together with some straightforward examples. These were used to test the implementation manually.

I'm not sure about the error handling of these two functions. The commands of the c-implementation print some additional information in case the `ioctl` calls return an error. Do you want to do this here as well?

PS: I hope this PR is welcome. We started using this crate and want to contribute back :)