### PR TITLE
ethercat-sys: update to bindgen 0.63

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Bindings have been pregenerated for revision `7fd991bec7` - if you activate the
 feature `pregenerated-bindings`, you don't need the master code to build, but
 the kernel modules must match that revision.
 
-The minimum tested Rust version is 1.48.0.
+The minimum tested Rust version is 1.58.1.
 
 # Licensing
 

--- a/ethercat-sys/Cargo.toml
+++ b/ethercat-sys/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 ioctl-sys = "0.5.2"
 
 [build-dependencies]
-bindgen = "0.59.0"
+bindgen = "0.63.0"
 
 [features]
 default = []

--- a/ethercat-sys/build.rs
+++ b/ethercat-sys/build.rs
@@ -55,7 +55,7 @@ fn main() {
                     continue;
                 }
 
-                let mut numparts = parts[2].split("(");
+                let mut numparts = parts[2].split('(');
                 let access = match numparts.next().unwrap() {
                     "EC_IO" => match name {
                         "SEND" | "SEND_EXT" => "arg",
@@ -74,9 +74,9 @@ fn main() {
                     "size_t" => "usize",
                     x => x,
                 });
-                write!(
+                writeln!(
                     &mut new,
-                    "ioctl!({:10} {:20} with EC, {}{}{});\n",
+                    "ioctl!({:10} {:20} with EC, {}{}{});",
                     access,
                     name,
                     number,


### PR DESCRIPTION
to avoid incompatibility with clang 16+.

This also changes the repr of size_t to usize instead of u64, removing the need for some casts.