### PR TITLE
add documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // Part of ethercat-rs. Copyright 2018-2022 by the authors.
 // This work is dual-licensed under Apache 2.0 and MIT terms.
 
+
 //! This crate provide an API that wraps IOCTL calls to the EthercCAT master kernel module developped by IgH/Etherlab.
 //! 	
 //! EtherCAT is an Ethernet-based fieldbus system, originally invented by Beckhoff GmbH but now used by numerous providers of automation related hardware. The IgH master lets you provide an EtherCAT master on a Linux machine without specialized hardware.
@@ -9,8 +10,20 @@
 //!
 //!	# typical cycle
 //!
+//! ```no_run
+//! # use ethercat::{
+//! #     AlState, DomainIdx as DomainIndex, Idx, Master, MasterAccess, Offset, PdoCfg, PdoEntryIdx,
+//! #     PdoEntryIdx as PdoEntryIndex, PdoEntryInfo, PdoEntryPos, PdoIdx, SlaveAddr, SlaveId, SlavePos,
+//! #     SmCfg, SubIdx, Result,
+//! # };
+//! # fn main() -> Result<()> {
+//! #    let master_idx = 0;
+//! #    let slave_pos = SlavePos::from(0);
+//! #    let slave_addr = SlaveAddr::ByPos(0);
+//! #    let slave_id = SlaveId {vendor_id: 0, product_code: 0};
+//! #
 //! 	// connecting to an ethercat master in the linux kernel
-//! 	let mut master = Master::open(idx, MasterAccess::ReadWrite)?;
+//! 	let mut master = Master::open(master_idx, MasterAccess::ReadWrite)?;
 //! 	master.reserve()?;
 //! 	// configure realtime transmissions
 //! 	let domain_idx = master.create_domain()?;
@@ -31,6 +44,9 @@
 //! 		let raw_data = master.domain_data(domain_idx)?;
 //! 		// ... do something with the process data
 //! 	}
+//! #
+//! # }
+//! ```
 
 
 use ethercat_sys as ec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,36 @@
 // Part of ethercat-rs. Copyright 2018-2022 by the authors.
 // This work is dual-licensed under Apache 2.0 and MIT terms.
 
-
-//! 	This crate provide an API that wraps IOCTL calls to the EthercCAT master kernel module developped by IgH/Etherlab.
+//! This crate provide an API that wraps IOCTL calls to the EthercCAT master kernel module developped by IgH/Etherlab.
 //! 	
-//! 	EtherCAT is an Ethernet-based fieldbus system, originally invented by Beckhoff GmbH but now used by numerous providers of automation related hardware. The IgH master lets you provide an EtherCAT master on a Linux machine without specialized hardware.
+//! EtherCAT is an Ethernet-based fieldbus system, originally invented by Beckhoff GmbH but now used by numerous providers of automation related hardware. The IgH master lets you provide an EtherCAT master on a Linux machine without specialized hardware.
 //! 	
-//! 	This crate mainly features struct [Master] - this struct is the entry point to the ethercat master kernel module, it exposes all its functions
+//! This crate mainly features struct [Master] - this struct is the entry point to the ethercat master kernel module, it exposes all its functions
+//!
+//!	# typical cycle
+//!
+//! 	// connecting to an ethercat master in the linux kernel
+//! 	let mut master = Master::open(idx, MasterAccess::ReadWrite)?;
+//! 	master.reserve()?;
+//! 	// configure realtime transmissions
+//! 	let domain_idx = master.create_domain()?;
+//! 	let mut config = master.configure_slave(slave_addr, slave_id)?;
+//! 	// ... perform some configuration
+//! 	
+//! 	// switch to operation and realtime mode
+//! 	master.request_state(slave_pos, AlState::Op)?;
+//! 	master.activate()?;
+//! 	
+//! 	loop {
+//! 		// execute the transmission steps
+//! 		master.receive()?;
+//! 		master.domain(domain_idx).process()?;
+//! 		master.domain(domain_idx).queue()?;
+//! 		master.send()?;
+//! 		
+//! 		let raw_data = master.domain_data(domain_idx)?;
+//! 		// ... do something with the process data
+//! 	}
 
 
 use ethercat_sys as ec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,14 @@
 // Part of ethercat-rs. Copyright 2018-2022 by the authors.
 // This work is dual-licensed under Apache 2.0 and MIT terms.
 
+
+//! 	This crate provide an API that wraps IOCTL calls to the EthercCAT master kernel module developped by IgH/Etherlab.
+//! 	
+//! 	EtherCAT is an Ethernet-based fieldbus system, originally invented by Beckhoff GmbH but now used by numerous providers of automation related hardware. The IgH master lets you provide an EtherCAT master on a Linux machine without specialized hardware.
+//! 	
+//! 	This crate mainly features struct [Master] - this struct is the entry point to the ethercat master kernel module, it exposes all its functions
+
+
 use ethercat_sys as ec;
 
 mod convert;

--- a/src/master.rs
+++ b/src/master.rs
@@ -242,10 +242,6 @@ impl Master {
 		## Parameters
 		
 		- `dev_idx` -	Index of the device (0 = main device, 1 = first backup device, ...). 
-		
-		## Returns
-		
-		Zero on success, otherwise negative error code. 
     */
     pub fn link_state(&self, dev_idx: u32) -> Result<MasterState> {
         let mut state = ec::ec_master_link_state_t::default();
@@ -716,12 +712,6 @@ impl Master {
 		## Attention
 			
 		The returned time is the system time of the reference clock minus the transmission delay of the reference clock.
-
-		## Return values
-		
-		0	success, system time was written into time.
-		-ENXIO	No reference clock found.
-		-EIO	Slave synchronization datagram was not received.
     */
     pub fn get_reference_clock_time(&mut self) -> Result<u32> {
         let mut time = 0;

--- a/src/types.rs
+++ b/src/types.rs
@@ -103,26 +103,43 @@ pub struct ConfigInfo {
     // syncs[*], watchdog_*, dc_*
 }
 
+/// Slave information
 #[derive(Debug, Clone)]
 pub struct SlaveInfo {
+	/// Display name of the slave
     pub name: String,
+	/// Offset of the slave in the ring
     pub ring_pos: u16,
+    /// Vendor-ID and product code stored on the slave
     pub id: SlaveId,
+    /// Revision-Number stored on the slave
     pub rev: SlaveRev,
+    /// The slaves alias if not equal to 0
     pub alias: u16,
+    /// Used current in mA
     pub current_on_ebus: i16,
+    /// Current state of the slave
     pub al_state: AlState,
+    /// Error flag for that slave
     pub error_flag: u8,
+    /// Number of sync managers
     pub sync_count: u8,
+    /// Number of SDOs
     pub sdo_count: u16,
+    /// Port information, statically sized to the max number of ports allowed by this library
     pub ports: [SlavePortInfo; ec::EC_MAX_PORTS as usize],
 }
 
+/// EtherCAT slave port descriptor
 #[derive(Debug, Clone, Copy)]
 pub enum SlavePortType {
+	/// Port is not implemented
     NotImplemented,
+    /// Port is not configured
     NotConfigured,
+    /// Port is an E-Bus
     EBus,
+    /// Port is a MII
     MII,
 }
 
@@ -134,17 +151,26 @@ impl Default for SlavePortType {
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SlavePortLink {
+	/// Link detected
     pub link_up: bool,
+    /// Loop closed
     pub loop_closed: bool,
+    /// Detected signal on RX port
     pub signal_detected: bool,
 }
 
+/// port information that can be retreived with a `SlaveInfo`
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SlavePortInfo {
+	/// Physical port type
     pub desc: SlavePortType,
+    /// Port link state
     pub link: SlavePortLink,
+    /// Receive time on DC transmission delay measurement
     pub receive_time: u32,
+    /// Ring position of next DC slave on that port
     pub next_slave: u16,
+    /// Delay [ns] to next DC slave
     pub delay_to_next_dc: u32,
 }
 


### PR DESCRIPTION
Hello everyone, thanks for having wrapped the etherlab kernel module !

I'm starting this PR to add rust documentation to the crate. My first motivation is to have at least some description so I can easier use that crate in a project of mine, so my documentation efforts will be driven by my specific need. The description I will write might eventually be oriented for my use when my understanding is not that good, so I will try to avoid this.

For now I only documented `Master`, `Domain`, `SlaveConfig` by copying the descriptions from the functions of etherlab's C library