### PR TITLE
Add EtherCAT example to list slaves

### DIFF
--- a/examples/list_slaves.rs
+++ b/examples/list_slaves.rs
@@ -22,13 +22,12 @@ pub fn main() -> Result<(), io::Error> {
                 found += 1;
             }
             Err(_) => {
-                // ignore errors for positions without a slave
+                println!("Slave pos {i}: <no slave>");
             }
         }
     }
 
     println!("Discovered {found} slaves (checked positions 0..31)");
 
-    // keep program alive if user wants to extend it interactively
     Ok(())
 }

--- a/examples/list_slaves.rs
+++ b/examples/list_slaves.rs
@@ -19,7 +19,7 @@ pub fn main() -> Result<(), io::Error> {
         let pos = SlavePos::from(i);
         match master.get_slave_info(pos) {
             Ok(info) => {
-                println!("Slave pos {}: {:?}", i, info);
+                println!("Slave pos {i}: {info:?}");
                 found += 1;
             }
             Err(_) => {

--- a/examples/list_slaves.rs
+++ b/examples/list_slaves.rs
@@ -6,7 +6,6 @@ use ethercat::{Master, SlavePos};
 use std::{io};
 
 pub fn main() -> Result<(), io::Error> {
-    // initialize logging
     env_logger::init();
 
     // open the first available master interface

--- a/examples/list_slaves.rs
+++ b/examples/list_slaves.rs
@@ -28,7 +28,7 @@ pub fn main() -> Result<(), io::Error> {
         }
     }
 
-    println!("Discovered {} slaves (checked positions 0..31)", found);
+    println!("Discovered {found} slaves (checked positions 0..31)");
 
     // keep program alive if user wants to extend it interactively
     Ok(())

--- a/examples/list_slaves.rs
+++ b/examples/list_slaves.rs
@@ -3,7 +3,7 @@
 //! Opens master 0 (read-only), queries slave info for positions 0..31 and
 //! prints discovered slaves.
 use ethercat::{Master, SlavePos};
-use std::{io};
+use std::io;
 
 pub fn main() -> Result<(), io::Error> {
     env_logger::init();

--- a/examples/list_slaves.rs
+++ b/examples/list_slaves.rs
@@ -1,0 +1,35 @@
+//! EtherCAT master example: List slaves
+//!
+//! Opens master 0 (read-only), queries slave info for positions 0..31 and
+//! prints discovered slaves.
+use ethercat::{Master, SlavePos};
+use std::{io};
+
+pub fn main() -> Result<(), io::Error> {
+    // initialize logging
+    env_logger::init();
+
+    // open the first available master interface
+    let master = Master::open(0, ethercat::MasterAccess::ReadOnly)?;
+
+    log::info!("Master opened. Attempting to list slaves (positions 0..31)...");
+
+    let mut found = 0u32;
+    for i in 0u16..=31 {
+        let pos = SlavePos::from(i);
+        match master.get_slave_info(pos) {
+            Ok(info) => {
+                println!("Slave pos {}: {:?}", i, info);
+                found += 1;
+            }
+            Err(_) => {
+                // ignore errors for positions without a slave
+            }
+        }
+    }
+
+    println!("Discovered {} slaves (checked positions 0..31)", found);
+
+    // keep program alive if user wants to extend it interactively
+    Ok(())
+}

--- a/examples/list_slaves.rs
+++ b/examples/list_slaves.rs
@@ -8,10 +8,12 @@ use std::{io};
 pub fn main() -> Result<(), io::Error> {
     env_logger::init();
 
-    // open the first available master interface
+    // Open /dev/EtherCAT0 (the first EtherCAT master) in read-only mode
+    // Prerequisites: You must configure the Etherlab EtherCAT master using `/etc/ethercat.conf`,
+    // and have the master running (e.g. via `sudo systemctl start ethercat`).
     let master = Master::open(0, ethercat::MasterAccess::ReadOnly)?;
 
-    log::info!("Master opened. Attempting to list slaves (positions 0..31)...");
+    log::info!("Master 0 opened. Attempting to list slaves (positions 0..31)...");
 
     let mut found = 0u32;
     for i in 0u16..=31 {


### PR DESCRIPTION
Stripped output:

```sh
$ cargo run --example list_slaves
Slave pos 0: SlaveInfo { name: "AS715N_sAxis_V0.10", ring_pos: 0, id: SlaveId { vendor_id: 4194304, product_code: 1813 }, rev: SlaveRev { revision_number: 12024, serial_number: 0 }, alias: 0, current_on_ebus: 0, al_state: PreOp, error_flag: 0, sync_count: 4, sdo_count: 0, ports: [SlavePortInfo { desc: MII, link: SlavePortLink { link_up: true, loop_closed: false, signal_detected: true }, receive_time: 979090354, next_slave: 65535, delay_to_next_dc: 0 }, SlavePortInfo { desc: MII, link: SlavePortLink { link_up: false, loop_closed: true, signal_detected: false }, receive_time: 1413563250, next_slave: 65535, delay_to_next_dc: 0 }, SlavePortInfo { desc: NotImplemented, link: SlavePortLink { link_up: false, loop_closed: true, signal_detected: false }, receive_time: 0, next_slave: 65535, delay_to_next_dc: 0 }, SlavePortInfo { desc: NotImplemented, link: SlavePortLink { link_up: false, loop_closed: true, signal_detected: false }, receive_time: 0, next_slave: 65535, delay_to_next_dc: 0 }] }
Discovered 1 slaves (checked positions 0..31)
```

The example compiles without any errors. I didn't want to add `serde_json` etc just for nicer formatting, since this is not really intended as a diagnostic tool, but more like a syntax example.
